### PR TITLE
Running GH actions only when necessary

### DIFF
--- a/.github/workflows/CI-collector.yml
+++ b/.github/workflows/CI-collector.yml
@@ -11,41 +11,8 @@ env:
   cache-version: 1
 
 jobs:
-  collect:
-    name: "Collect dry-run"
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: packages/collector
-    steps:
-      - name: "Checkout"
-        uses: actions/checkout@v2.4.0
-
-      - name: "Cache NPM dependencies"
-        uses: actions/cache@v2.1.7
-        with:
-          path: "~/.npm"
-          key: npm-dependencies-${{ runner.os }}-${{ env.cache-version }}-${{ hashFiles('package.json') }}
-          restore-keys: |
-            npm-dependencies-${{ runner.os }}-${{ env.cache-version }}-${{ hashFiles('package.json') }}
-            npm-dependencies-${{ runner.os }}-${{ env.cache-version }}-
-            npm-dependencies-${{ runner.os }}-
-
-      - name: "Install NPM dependencies"
-        run: |
-          npm ci --no-dev
-
-      - name: "Collect"
-        run: |
-          npm run collect
-        env:
-          PAT: ${{ secrets.PAT_PETA }}
-
-      - name: "Upload artifact"
-        uses: actions/upload-artifact@v2
-        with:
-          name: "listings"
-          path: listings.json
+  collect-dry-run:
+    uses: ./.github/workflows/reusable/collect
 
   collector-lint:
     name: "Lint collector"

--- a/.github/workflows/CI-collector.yml
+++ b/.github/workflows/CI-collector.yml
@@ -1,74 +1,16 @@
-name: "CI"
+name: "collector CI"
 on:
   push:
     branches:
       - master
   pull_request:
+    paths:
+      - 'config.json'
+      - 'packages/collector/**'
 env:
   cache-version: 1
 
 jobs:
-  frontend-build:
-    name: "Build frontend"
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: packages/frontend
-    steps:
-      - name: "Checkout"
-        uses: actions/checkout@v2.4.0
-
-      - name: "Cache NPM dependencies"
-        uses: actions/cache@v2.1.7
-        with:
-          path: "~/.npm"
-          key: npm-dependencies-${{ runner.os }}-${{ env.cache-version }}-${{ hashFiles('package.json') }}
-          restore-keys: |
-            npm-dependencies-${{ runner.os }}-${{ env.cache-version }}-${{ hashFiles('package.json') }}
-            npm-dependencies-${{ runner.os }}-${{ env.cache-version }}-
-            npm-dependencies-${{ runner.os }}-
-
-      - name: "Install NPM dependencies"
-        run: |
-          npm ci
-
-      - name: "Build"
-        run: |
-          npm run build
-
-  frontend-test:
-    name: "Test frontend"
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: packages/frontend
-    steps:
-      - name: "Checkout"
-        uses: actions/checkout@v2.4.0
-
-      - name: "Cache NPM dependencies"
-        uses: actions/cache@v2.1.7
-        with:
-          path: "~/.npm"
-          key: npm-dependencies-${{ runner.os }}-${{ env.cache-version }}-${{ hashFiles('package.json') }}
-          restore-keys: |
-            npm-dependencies-${{ runner.os }}-${{ env.cache-version }}-${{ hashFiles('package.json') }}
-            npm-dependencies-${{ runner.os }}-${{ env.cache-version }}-
-            npm-dependencies-${{ runner.os }}-
-
-      - name: "Install NPM dependencies"
-        run: |
-          npm ci
-
-      - name: "Test"
-        run: |
-          npm run test
-
-      - name: "Upload coverage results"
-        uses: codecov/codecov-action@v2.1.0
-        with:
-          flags: frontend
-
   collect:
     name: "Collect dry-run"
     runs-on: ubuntu-latest

--- a/.github/workflows/CI-collector.yml
+++ b/.github/workflows/CI-collector.yml
@@ -1,4 +1,4 @@
-name: "collector CI"
+name: "Collector CI"
 on:
   push:
     branches:

--- a/.github/workflows/CI-collector.yml
+++ b/.github/workflows/CI-collector.yml
@@ -5,15 +5,11 @@ on:
       - master
   pull_request:
     paths:
-      - 'config.json'
       - 'packages/collector/**'
 env:
   cache-version: 1
 
 jobs:
-  collect-dry-run:
-    uses: ./.github/workflows/reusable/collect
-
   collector-lint:
     name: "Lint collector"
     runs-on: ubuntu-latest

--- a/.github/workflows/CI-config.yml
+++ b/.github/workflows/CI-config.yml
@@ -1,0 +1,14 @@
+name: "Config CI"
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    paths:
+      - 'config.json'
+env:
+  cache-version: 1
+
+jobs:
+  collect-dry-run:
+    uses: ./.github/workflows/reusable/collect

--- a/.github/workflows/CI-frontend.yml
+++ b/.github/workflows/CI-frontend.yml
@@ -1,0 +1,72 @@
+name: "CI"
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    paths:
+      - 'packages/frontend/**'
+env:
+  cache-version: 1
+
+jobs:
+  frontend-build:
+    name: "Build frontend"
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/frontend
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v2.4.0
+
+      - name: "Cache NPM dependencies"
+        uses: actions/cache@v2.1.7
+        with:
+          path: "~/.npm"
+          key: npm-dependencies-${{ runner.os }}-${{ env.cache-version }}-${{ hashFiles('package.json') }}
+          restore-keys: |
+            npm-dependencies-${{ runner.os }}-${{ env.cache-version }}-${{ hashFiles('package.json') }}
+            npm-dependencies-${{ runner.os }}-${{ env.cache-version }}-
+            npm-dependencies-${{ runner.os }}-
+
+      - name: "Install NPM dependencies"
+        run: |
+          npm ci
+
+      - name: "Build"
+        run: |
+          npm run build
+
+  frontend-test:
+    name: "Test frontend"
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/frontend
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v2.4.0
+
+      - name: "Cache NPM dependencies"
+        uses: actions/cache@v2.1.7
+        with:
+          path: "~/.npm"
+          key: npm-dependencies-${{ runner.os }}-${{ env.cache-version }}-${{ hashFiles('package.json') }}
+          restore-keys: |
+            npm-dependencies-${{ runner.os }}-${{ env.cache-version }}-${{ hashFiles('package.json') }}
+            npm-dependencies-${{ runner.os }}-${{ env.cache-version }}-
+            npm-dependencies-${{ runner.os }}-
+
+      - name: "Install NPM dependencies"
+        run: |
+          npm ci
+
+      - name: "Test"
+        run: |
+          npm run test
+
+      - name: "Upload coverage results"
+        uses: codecov/codecov-action@v2.1.0
+        with:
+          flags: frontend

--- a/.github/workflows/CI-frontend.yml
+++ b/.github/workflows/CI-frontend.yml
@@ -1,4 +1,4 @@
-name: "CI"
+name: "Frontend CI"
 on:
   push:
     branches:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,7 +1,8 @@
 name: "CI"
 on:
   push:
-    branches: "*"
+    branches:
+      - master
   pull_request:
 env:
   cache-version: 1

--- a/.github/workflows/collect.yml
+++ b/.github/workflows/collect.yml
@@ -13,40 +13,7 @@ env:
 
 jobs:
   collect:
-    name: "Collect"
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: packages/collector
-    steps:
-      - name: "Checkout"
-        uses: actions/checkout@v2.4.0
-
-      - name: "Cache NPM dependencies"
-        uses: actions/cache@v2.1.7
-        with:
-          path: "~/.npm"
-          key: npm-dependencies-${{ runner.os }}-${{ env.cache-version }}-${{ hashFiles('package.json') }}
-          restore-keys: |
-            npm-dependencies-${{ runner.os }}-${{ env.cache-version }}-${{ hashFiles('package.json') }}
-            npm-dependencies-${{ runner.os }}-${{ env.cache-version }}-
-            npm-dependencies-${{ runner.os }}-
-
-      - name: "Install NPM dependencies"
-        run: |
-          npm ci --no-dev
-
-      - name: "Collect"
-        run: |
-          npm run collect
-        env:
-          PAT: ${{ secrets.PAT_PETA }}
-
-      - name: "Upload artifact"
-        uses: actions/upload-artifact@v2
-        with:
-          name: "listings"
-          path: listings.json
+    uses: ./.github/workflows/reusable/collect
 
   deploy:
     name: "Deploy"

--- a/.github/workflows/collect.yml
+++ b/.github/workflows/collect.yml
@@ -16,7 +16,7 @@ jobs:
     uses: ./.github/workflows/reusable/collect
 
   deploy:
-    name: "Deploy"
+    name: "Deploy collected listings"
     runs-on: ubuntu-latest
     needs: collect
     defaults:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: "Deploy"
+name: "Deploy frontend"
 on:
   push:
     branches:
@@ -10,7 +10,7 @@ env:
 
 jobs:
   build:
-    name: "Build"
+    name: "Build frontend"
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -44,7 +44,7 @@ jobs:
           path: packages/frontend/build
 
   deploy:
-    name: "Deploy"
+    name: "Deploy frontend"
     runs-on: ubuntu-latest
     needs: build
     steps:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,10 @@
 name: "Deploy"
 on:
   push:
-    branches: "master"
+    branches:
+      - master
+    paths:
+      - 'packages/frontend/**'
 env:
   cache-version: 1
 

--- a/.github/workflows/reusable/collect.yml
+++ b/.github/workflows/reusable/collect.yml
@@ -1,0 +1,42 @@
+name: "Collect"
+on:
+  workflow_call:
+env:
+  cache-version: 1
+
+jobs:
+  collect:
+    name: "Collect"
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/collector
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v2.4.0
+
+      - name: "Cache NPM dependencies"
+        uses: actions/cache@v2.1.7
+        with:
+          path: "~/.npm"
+          key: npm-dependencies-${{ runner.os }}-${{ env.cache-version }}-${{ hashFiles('package.json') }}
+          restore-keys: |
+            npm-dependencies-${{ runner.os }}-${{ env.cache-version }}-${{ hashFiles('package.json') }}
+            npm-dependencies-${{ runner.os }}-${{ env.cache-version }}-
+            npm-dependencies-${{ runner.os }}-
+
+      - name: "Install NPM dependencies"
+        run: |
+          npm ci --no-dev
+
+      - name: "Collect"
+        run: |
+          npm run collect
+        env:
+          PAT: ${{ secrets.PAT_PETA }}
+
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@v2
+        with:
+          name: "listings"
+          path: listings.json


### PR DESCRIPTION
Closes #260

- Only deploying frontend on frontend changes
- Not running CI on every commit to every branch
- Split CI between packages
- Deduplicated collector action
- Split out CI config
