### PR TITLE
Re-enabled dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -9,7 +9,7 @@ jobs:
   dependabot:
     name: "Dependabot auto-merge"
     runs-on: ubuntu-latest
-    if: ${{ false && github.actor == 'dependabot[bot]' }}
+    if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
       - name: "Enable auto-merge for the request"
         run: gh pr merge --auto --merge "$PR_URL"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -11,6 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
+      - name: "Wait for checks to finish"
+        run: gh pr checks --watch
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: "Enable auto-merge for the request"
         run: gh pr merge --auto --merge "$PR_URL"
         env:


### PR DESCRIPTION
The original implementation only checks for success of all **required** workflows. Since we have none (instead running them only when packages are modified), it would merge even failing PRs.

Waiting on cli/cli#4519 since that could be used to check for workflows passing.
