### PR TITLE
Removed react-router as a direct dependency

### DIFF
--- a/packages/frontend/package-lock.json
+++ b/packages/frontend/package-lock.json
@@ -14,7 +14,6 @@
         "react-dom": "^18.2.0",
         "react-icons": "^4.9.0",
         "react-markdown": "^8.0.7",
-        "react-router": "^6.11.2",
         "react-router-dom": "^6.14.0",
         "remark-gfm": "^3.0.1",
         "string-to-color": "^2.2.2",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -31,7 +31,6 @@
     "react-dom": "^18.2.0",
     "react-icons": "^4.9.0",
     "react-markdown": "^8.0.7",
-    "react-router": "^6.11.2",
     "react-router-dom": "^6.14.0",
     "remark-gfm": "^3.0.1",
     "string-to-color": "^2.2.2",

--- a/packages/frontend/src/pages/IssueDetail.tsx
+++ b/packages/frontend/src/pages/IssueDetail.tsx
@@ -3,7 +3,7 @@ import { css } from "@emotion/react"
 import type React from "react"
 import { AiFillGithub } from "react-icons/ai"
 import ReactMarkdown from "react-markdown"
-import { useParams } from "react-router"
+import { useParams } from "react-router-dom"
 import { Link } from "react-router-dom"
 import remarkGfm from "remark-gfm"
 

--- a/packages/frontend/src/pages/ProjectDetail.tsx
+++ b/packages/frontend/src/pages/ProjectDetail.tsx
@@ -2,7 +2,7 @@
 import { css } from "@emotion/react"
 import type React from "react"
 import ReactMarkdown from "react-markdown"
-import { useParams } from "react-router"
+import { useParams } from "react-router-dom"
 import remarkGfm from "remark-gfm"
 
 import { ColoredTag } from "../components/ColoredTag"


### PR DESCRIPTION
It's still a transitive dependency, but this makes updates easier.
