### PR TITLE
Don't count test helpers in coverage

### DIFF
--- a/packages/collector/vitest.config.ts
+++ b/packages/collector/vitest.config.ts
@@ -2,6 +2,9 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
+    coverage: {
+      exclude: ["tests/**"],
+    },
     mockReset: true,
     setupFiles: ["tests/setup.ts"],
   },

--- a/packages/frontend/vite.config.js
+++ b/packages/frontend/vite.config.js
@@ -9,6 +9,9 @@ export default defineConfig({
   plugins: [legacy(), react()],
   root: "src",
   test: {
+    coverage: {
+      exclude: ["tests/**"],
+    },
     environment: "jsdom",
     mockReset: true,
     root: ".",


### PR DESCRIPTION
The tests directory was being measured as if it were production code.
Vitest's default `coverage.exclude` matches test *file name* patterns
(`**/*.{test,spec}.*`) rather than test *directories*, so files under
`tests/` that don't carry `.test.` in their name were instrumented, because
the tests import them.

In this repository `packages/frontend/tests/testData.ts` was the only such
file, a single measured line, so the reported figure does not change. The
same exclusion is added to the collector package as well, so that the two
packages stay configured alike and the problem cannot reappear there.

Exclude `tests/**` from coverage. Doing this in the vitest config rather than
through `codecov.yml`'s `ignore` key keeps a local `npm run test-coverage` run
consistent with CI, and leaves `codecov.yml` byte-identical across all the
repositories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)